### PR TITLE
add semantic release branches attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ You can also optionally set:
 - `KIRA_RELEASE_ASSETS` to any [assets](https://github.com/semantic-release/git#assets) string, so it will upload these files to GitLab release
 - `KIRA_RELEASE_EXEC_CONFIG` string with `json` config to pass to [`@semantic-release/exec`](https://github.com/semantic-release/exec). Related docs on [why](https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-use-a-npm-build-script-that-requires-the-package-jsons-version) would you possibly need this
 - `KIRA_RELEASE_REPLACE_CONFIG` string with `json` config of how to [bump version numbers](https://github.com/google/semantic-release-replace-plugin) in a project definition file, example: `KIRA_RELEASE_REPLACE_CONFIG='{ "project": "package.json", "from": "\"version\": \".*\"", "to": "\"version\": \"${nextRelease.version}\"" }'`
+- `KIRA_RELEASE_BRANCHES` [to semantic release branches](https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches) default: ['master',  'main']
 
 **Note:** You might want to use `$$` to escape `$` char in several environments like GitLab CI configuration file
-
 
 ## Running
 

--- a/release.config.js
+++ b/release.config.js
@@ -16,6 +16,7 @@ const replaceConfig = JSON.parse(
 )
 const execConfig = JSON.parse(process.env.KIRA_RELEASE_EXEC_CONFIG || '{}')
 const skipDocker = process.env.KIRA_RELEASE_SKIP_DOCKER
+const branches = process.env.KIRA_RELEASE_BRANCHES || ['master', 'main']
 
 // Files to be committed back to the repo later on:
 const toBeCommitted = ['CHANGELOG.md']
@@ -35,6 +36,7 @@ console.log('Going to commit:', toBeCommitted)
 
 // Pipeline definition:
 const releasePipeline = {
+  'branches': branches,
   'plugins': [
     '@semantic-release/commit-analyzer',
     '@semantic-release/release-notes-generator',

--- a/release.config.js
+++ b/release.config.js
@@ -16,7 +16,7 @@ const replaceConfig = JSON.parse(
 )
 const execConfig = JSON.parse(process.env.KIRA_RELEASE_EXEC_CONFIG || '{}')
 const skipDocker = process.env.KIRA_RELEASE_SKIP_DOCKER
-const branches = process.env.KIRA_RELEASE_BRANCHES || ['master', 'main']
+const branches = JSON.parse(process.env.KIRA_RELEASE_BRANCHES || '["master", "main"]')
 
 // Files to be committed back to the repo later on:
 const toBeCommitted = ['CHANGELOG.md']


### PR DESCRIPTION
Gitlab changed default branch to 'main' with GitLab 14.0 or later. 

https://docs.gitlab.com/ee/user/project/repository/branches/default.html

And semantic-release default branches attribute doesn't include 'main' branch.

https://semantic-release.gitbook.io/semantic-release/usage/configuration#branches

So I made it manageable with env.
