### PR TITLE
fix: add default asset value, no more required to set assets as a default everytime

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -10,7 +10,7 @@
 // See README.md for more options and their description.
 
 // Configuration:
-const assets = process.env.KIRA_RELEASE_ASSETS || ''
+const assets = process.env.KIRA_RELEASE_ASSETS || '[]'
 const replaceConfig = JSON.parse(
   process.env.KIRA_RELEASE_REPLACE_CONFIG || '{}',
 )


### PR DESCRIPTION
Also this pr fixes following error while not set `KIRA_RELEASE_ASSETS` option with default value.
- `SemanticReleaseError: Invalid "assets" option.`